### PR TITLE
【Fixed】`rails g` コマンドの際にassetsファイル

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,9 @@ module FlowSample
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
   end
 end


### PR DESCRIPTION
#1 

・config/application.rbに「rails g controller」時に、assetsファイルとhelperクラスの生成を抑制する設定を追加。