### PR TITLE
【Fixed】#2 `rails g`コマンドの際に不要なhelper,assetsファイルを自動生成しないように改善

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,19 +17,11 @@ Bundler.require(*Rails.groups)
 
 module FlowSample
   class Application < Rails::Application
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
-
-    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
-
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
-
-    # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
   end
 end


### PR DESCRIPTION
#2
下記の内容を実行し、issue#2の確認をお願いします。
- [ １] 'rails g'コマンドの際にhelperとassetsファイルを自動生成されないように
　　　/config/application.rbを編集しました。