### PR TITLE
【fixed】`rails g`コマンドの際にいらないファイルが生成されないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,6 @@ module FlowSample
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
-    
     config.generators do |g|
       g.assets     false
       g.helper     false

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,9 +31,10 @@ module FlowSample
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+    
     config.generators do |g|
       g.assets     false
       g.helper     false
-    end    
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,7 @@ module FlowSample
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+    
     config.generators do |g|
       g.assets     false
       g.helper     false

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,9 @@ module FlowSample
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end    
   end
 end


### PR DESCRIPTION
#1

config/application.rb に対して下記のコードを追加

module FrowSample
  class Application < Rails::Application
    #...
    config.generators do |g|
      g.assets     false
      g.helper     false
    end
    #...
  end
end
