### PR TITLE
【Fixed】`rails g`コマンドの際にassetsファイル、helperが作成されないように改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@
 /log/*
 !/log/.keep
 /tmp
+
+.DS_store
+.env
+public/uploads/
+vendor/bundle

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,9 @@ module FlowSample
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+    config.generators do |g|
+      g.assets  false
+      g.helper  false
+    end
   end
 end


### PR DESCRIPTION
#1 

- config/application.rbにrails g時にassetsとhelperを生成しないよう設定を記載

参考本：http://blog.willnet.in/entry/2012/09/02/220124