### PR TITLE
【fixed】`rails g`コマンドの際にいらないファイルが生成されないように改善

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,9 @@ module FlowSample
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
   end
 end


### PR DESCRIPTION
#1 

・assets, helper生成のデフォルトをfalseに設定